### PR TITLE
Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+dist
+__pycache__
+*.egg-info

--- a/picoparse/__init__.py
+++ b/picoparse/__init__.py
@@ -103,7 +103,12 @@ class EOF:
     def __str__(self): return "EOF"
     def __repr__(self): return "EOF()"
     def __nonzero__(self): return False
-    def __gt__(self, other): return True
+    def __gt__(self, other):
+        if type(other) != EOF:
+            return True
+        return False
+    def __lt__(self, other):
+        return False
 
 
 EndOfFile = EOF()

--- a/picoparse/__init__.py
+++ b/picoparse/__init__.py
@@ -132,7 +132,7 @@ class BufferWalker:
             diag = DefaultDiagnostics()
         self.source = diag.wrap(iter(source))
         try:
-            self.buffer = [self.source.__next__()]
+            self.buffer = [next(self.source)]
         except StopIteration:
             self.buffer = []
         self.index = 0
@@ -149,12 +149,12 @@ class BufferWalker:
         """fills the internal buffer from the source iterator"""
         try:
             for i in range(size):
-                self.buffer.append(self.source.__next__())
+                self.buffer.append(next(self.source))
         except StopIteration:
             self.buffer.append((EndOfFile, EndOfFile))
         self.len = len(self.buffer)
     
-    def next(self):
+    def __next__(self):
         """Advances to and returns the next token or returns EndOfFile"""
         self.index += 1
         t = self.peek()
@@ -265,7 +265,7 @@ def p(name, parser, *args1, **kwargs1):
             raise
     return p_desc
 
-next = lambda: local_ps.value.next()
+next_token = lambda: next(local_ps.value)
 peek = lambda: local_ps.value.peek()
 fail = lambda expecting=[]: local_ps.value.fail(expecting)
 commit = lambda: local_ps.value.commit()
@@ -321,7 +321,7 @@ def any_token():
     ch = peek()
     if ch is EndOfFile:
         fail(["not eof"])
-    next()
+    next_token()
     return ch
 
 def one_of(these):
@@ -336,7 +336,7 @@ def one_of(these):
     except TypeError:
         if ch != these:
             fail([these])
-    next()
+    next_token()
     return ch
 
 def not_one_of(these):
@@ -352,7 +352,7 @@ def not_one_of(these):
     except TypeError:
         if ch != these:
             fail([desc])
-    next()
+    next_token()
     return ch
 
 def _fun_to_str(f):
@@ -373,7 +373,7 @@ def satisfies(guard):
     i = peek()
     if (i is EndOfFile) or (not guard(i)):
         fail(["<satisfies predicate " + _fun_to_str(guard) + ">"])
-    next()
+    next_token()
     return i
 
 def optional(parser, default=None):
@@ -500,7 +500,7 @@ def remaining():
     tokens = []
     while peek() is not EndOfFile:
         tokens.append(peek())
-        next()
+        next_token()
     return tokens
 
 def seq(*sequence):

--- a/picoparse/text.py
+++ b/picoparse/text.py
@@ -126,7 +126,7 @@ class TextDiagnostics:
     def wrap(self, stream):
         try:
             while True:
-                ch = stream.__next__()
+                ch = next(stream)
                 self.line.append(ch)
                 if ch == '\n':
                     for tok in self.emit_line():

--- a/picoparse/text.py
+++ b/picoparse/text.py
@@ -88,7 +88,7 @@ def caseless_literal(s):
     return make_caseless_literal(s)()
 
 
-class Pos(object):
+class Pos:
     def __init__(self, row, col):
         self.row = row
         self.col = col
@@ -97,7 +97,7 @@ class Pos(object):
         return str(self.row) + ":" + str(self.col)
 
 
-class TextDiagnostics(object):
+class TextDiagnostics:
     def __init__(self):
         self.lines = []
         self.row = 1
@@ -126,7 +126,7 @@ class TextDiagnostics(object):
     def wrap(self, stream):
         try:
             while True:
-                ch = stream.next()
+                ch = stream.__next__()
                 self.line.append(ch)
                 if ch == '\n':
                     for tok in self.emit_line():

--- a/picoparse/text.py
+++ b/picoparse/text.py
@@ -96,6 +96,12 @@ class Pos:
     def __str__(self):
         return str(self.row) + ":" + str(self.col)
 
+    def __gt__(self, other):
+        try:
+            return (self.row, self.col) > (other.row, other.col)
+        except AttributeError:
+            return False
+
 
 class TextDiagnostics:
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 try:
     from setuptools import setup
 except ImportError:

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2009, Andrew Brehaut, Steven Ashley
 # All rights reserved.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2009, Andrew Brehaut, Steven Ashley
 # All rights reserved.
 # 
@@ -23,9 +23,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 # POSSIBILITY OF SUCH DAMAGE.
 
-from backend import *
-from core_parsers import *
-from text_parsers import *
+from .backend import *
+from .core_parsers import *
+from .text_parsers import *
 import unittest
 
 if __name__ == '__main__':

--- a/tests/backend.py
+++ b/tests/backend.py
@@ -56,9 +56,9 @@ class TestDefaultDiagnostics(unittest.TestCase):
              self.assertEqual(self.diag.tokens, list(zip(range(1, a+1),range(1, a+1))))
     
     def test_cut(self):
-        self.i.__next__()
-        self.i.__next__()
-        c, p = self.i.__next__()
+        next(self.i)
+        next(self.i)
+        c, p = next(self.i)
         self.diag.cut(p)
         self.assertEqual(self.diag.tokens, [(3,3)])
 
@@ -72,34 +72,34 @@ class TestBufferWalker(unittest.TestCase):
 
     def test_next(self):
         for c in self.input[1:]:
-            self.assertEqual(self.bw.next(), c)
+            self.assertEqual(next(self.bw), c)
     
     def test_peek(self):
         for c in self.input:
             self.assertEqual(self.bw.peek(), c)
-            self.bw.next()
+            next(self.bw)
     
     def test_current(self):
         for c, pos in zip(self.input, count(1)):
             self.assertEqual(self.bw.current(), (c, pos))
-            self.bw.next()
+            next(self.bw)
     
     def test_pos(self):
         for c, pos in zip(self.input, count(1)):
             self.assertEqual(self.bw.pos(), pos)
-            self.bw.next()
+            next(self.bw)
     
     def test_fail(self):
         self.assertRaises(NoMatch, self.bw.fail)
         self.assertEqual(self.bw.peek(), 'a')
     
     def test_tri_accept(self):
-        self.bw.tri(self.bw.next)
+        self.bw.tri(self.bw.__next__)
         self.assertEqual(self.bw.peek(), 'b')
     
     def test_tri_fail(self):
         def fun():
-            self.bw.next()
+            next(self.bw)
             self.bw.fail()
         self.assertRaises(NoMatch, p(self.bw.tri, fun))
 
@@ -112,14 +112,14 @@ class TestBufferWalker(unittest.TestCase):
 
     def test_commit_accept(self):
         def fun():
-            self.bw.next()
+            next(self.bw)
             self.bw.commit()
         self.bw.tri(fun)
         self.assertEqual(self.bw.peek(), 'b')
     
     def test_commit_fail(self):
         def fun():
-            self.bw.next()
+            next(self.bw)
             self.bw.commit()
             self.bw.fail()
         self.assertRaises(NoMatch, p(self.bw.tri, fun))
@@ -129,9 +129,9 @@ class TestBufferWalker(unittest.TestCase):
         self.bw.choice()
     
     def test_choice_accept(self):
-        self.bw.choice(self.bw.fail, self.bw.next)
-        self.bw.choice(self.bw.next, self.bw.fail)
-        self.bw.choice(self.bw.next, self.bw.next)
+        self.bw.choice(self.bw.fail, self.bw.__next__)
+        self.bw.choice(self.bw.__next__, self.bw.fail)
+        self.bw.choice(self.bw.__next__, self.bw.__next__)
         self.assertEqual(self.bw.peek(), 'd')
     
     def test_choice_fail(self):
@@ -139,7 +139,7 @@ class TestBufferWalker(unittest.TestCase):
     
     def test_choice_commit_fail(self):
         def fun():
-            self.bw.next()
+            next(self.bw)
             self.bw.commit()
             self.bw.fail()
         self.assertRaises(NoMatch, p(self.bw.choice, fun))

--- a/tests/backend.py
+++ b/tests/backend.py
@@ -32,7 +32,7 @@ import unittest
 
 from picoparse import NoMatch, DefaultDiagnostics, BufferWalker
 from picoparse import partial as p
-from itertools import count, izip
+from itertools import count
 
 class TestDefaultDiagnostics(unittest.TestCase):
     """Checks some basic operations on the DefaultDiagnostics class
@@ -40,27 +40,27 @@ class TestDefaultDiagnostics(unittest.TestCase):
     """
     def setUp(self):
         self.diag = DefaultDiagnostics()
-        self.i = self.diag.wrap(xrange(1, 6))
+        self.i = self.diag.wrap(range(1, 6))
 
     def test_wrap(self):
-        for ((a, b), c) in izip(self.i, xrange(1, 6)):
-             self.assertEquals(a, c)
-             self.assertEquals(b, c)
+        for ((a, b), c) in zip(self.i, range(1, 6)):
+             self.assertEqual(a, c)
+             self.assertEqual(b, c)
     
     def test_wrap_len(self):
-        self.assertEquals(len(list(self.i)), 5)
+        self.assertEqual(len(list(self.i)), 5)
     
     def test_tokens(self):
-        self.assertEquals(self.diag.tokens, [])
+        self.assertEqual(self.diag.tokens, [])
         for (a, b) in self.i:
-             self.assertEquals(self.diag.tokens, zip(range(1, a+1),range(1, a+1)))
+             self.assertEqual(self.diag.tokens, list(zip(range(1, a+1),range(1, a+1))))
     
     def test_cut(self):
-        self.i.next()
-        self.i.next()
-        c, p = self.i.next()
+        self.i.__next__()
+        self.i.__next__()
+        c, p = self.i.__next__()
         self.diag.cut(p)
-        self.assertEquals(self.diag.tokens, [(3,3)])
+        self.assertEqual(self.diag.tokens, [(3,3)])
 
 
 class TestBufferWalker(unittest.TestCase):
@@ -72,30 +72,30 @@ class TestBufferWalker(unittest.TestCase):
 
     def test_next(self):
         for c in self.input[1:]:
-            self.assertEquals(self.bw.next(), c)
+            self.assertEqual(self.bw.next(), c)
     
     def test_peek(self):
         for c in self.input:
-            self.assertEquals(self.bw.peek(), c)
+            self.assertEqual(self.bw.peek(), c)
             self.bw.next()
     
     def test_current(self):
-        for c, pos in izip(self.input, count(1)):
-            self.assertEquals(self.bw.current(), (c, pos))
+        for c, pos in zip(self.input, count(1)):
+            self.assertEqual(self.bw.current(), (c, pos))
             self.bw.next()
     
     def test_pos(self):
-        for c, pos in izip(self.input, count(1)):
-            self.assertEquals(self.bw.pos(), pos)
+        for c, pos in zip(self.input, count(1)):
+            self.assertEqual(self.bw.pos(), pos)
             self.bw.next()
     
     def test_fail(self):
         self.assertRaises(NoMatch, self.bw.fail)
-        self.assertEquals(self.bw.peek(), 'a')
+        self.assertEqual(self.bw.peek(), 'a')
     
     def test_tri_accept(self):
         self.bw.tri(self.bw.next)
-        self.assertEquals(self.bw.peek(), 'b')
+        self.assertEqual(self.bw.peek(), 'b')
     
     def test_tri_fail(self):
         def fun():
@@ -115,7 +115,7 @@ class TestBufferWalker(unittest.TestCase):
             self.bw.next()
             self.bw.commit()
         self.bw.tri(fun)
-        self.assertEquals(self.bw.peek(), 'b')
+        self.assertEqual(self.bw.peek(), 'b')
     
     def test_commit_fail(self):
         def fun():
@@ -123,7 +123,7 @@ class TestBufferWalker(unittest.TestCase):
             self.bw.commit()
             self.bw.fail()
         self.assertRaises(NoMatch, p(self.bw.tri, fun))
-        self.assertEquals(self.bw.peek(), 'b')
+        self.assertEqual(self.bw.peek(), 'b')
     
     def test_choice_null(self):
         self.bw.choice()
@@ -132,7 +132,7 @@ class TestBufferWalker(unittest.TestCase):
         self.bw.choice(self.bw.fail, self.bw.next)
         self.bw.choice(self.bw.next, self.bw.fail)
         self.bw.choice(self.bw.next, self.bw.next)
-        self.assertEquals(self.bw.peek(), 'd')
+        self.assertEqual(self.bw.peek(), 'd')
     
     def test_choice_fail(self):
         self.assertRaises(NoMatch, p(self.bw.choice, self.bw.fail, self.bw.fail))
@@ -143,7 +143,7 @@ class TestBufferWalker(unittest.TestCase):
             self.bw.commit()
             self.bw.fail()
         self.assertRaises(NoMatch, p(self.bw.choice, fun))
-        self.assertEquals(self.bw.peek(), 'b')
+        self.assertEqual(self.bw.peek(), 'b')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/core_parsers.py
+++ b/tests/core_parsers.py
@@ -38,7 +38,7 @@ from picoparse import sep, sep1
 from picoparse import cue, follow, seq, string
 from picoparse import not_followed_by, remaining
 
-from utils import ParserTestCase
+from .utils import ParserTestCase
 
 # some simple parsers
 nothing = p(one_of, '')

--- a/tests/text_parsers.py
+++ b/tests/text_parsers.py
@@ -30,33 +30,33 @@ if __name__ == '__main__':
 
 import unittest
 
-import core_parsers
+from . import core_parsers
 import string
 from picoparse import partial as p
 from picoparse.text import newline, whitespace_char, whitespace, whitespace1
 from picoparse.text import lexeme, quote, quoted, caseless_string, run_text_parser
 
-from utils import TextParserTestCase
+from .utils import TextParserTestCase
 
 class TestTextTokenConsumers(core_parsers.TestTokenConsumers):
     def run_parser(self, *args):
-		return run_text_parser(*args)
+        return run_text_parser(*args)
 		
 class TestTextManyCombinators(core_parsers.TestManyCombinators):
     def run_parser(self, *args):
-		return run_text_parser(*args)
+        return run_text_parser(*args)
 
 class TestTextSeparatorCombinators(core_parsers.TestSeparatorCombinators):
     def run_parser(self, *args):
-		return run_text_parser(*args)
+        return run_text_parser(*args)
 
 class TestTextSequencingCombinators(core_parsers.TestSequencingCombinators):
     def run_parser(self, *args):
-		return run_text_parser(*args)
+        return run_text_parser(*args)
 
 class TestTextFuture(core_parsers.TestFuture):
     def run_parser(self, *args):
-		return run_text_parser(*args)
+        return run_text_parser(*args)
 
 whitespace_strings = [' ', '  ', '   ', '\n', '\t', '\n \n\r\t\n \t']
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,7 @@ class ParserTestCase(unittest.TestCase):
     """Handles a match
     """
     def assertMatch(self, parser, input, expected, remaining, *args):
-        self.assertEquals(self.run_parser(parser, input), (expected, list(remaining)), *args)
+        self.assertEqual(self.run_parser(parser, input), (expected, list(remaining)), *args)
 
     """Handles the common case that a parser doesnt match input.
     """


### PR DESCRIPTION
Hello, 

I've ported picoparse to python3.
This version is not compatible with python 2.

Moreover, 'next' is now reserved in python3. I'd had to change the api and rename 'next' to 'next_token'

Regards,
Matthieu Gautier.
